### PR TITLE
Add support for 10.15 (Catalina).

### DIFF
--- a/www/chart-graphs.js
+++ b/www/chart-graphs.js
@@ -840,7 +840,7 @@ ChartDisplay.prototype.drawMacStats = function ()
     return 'Unknown';
   }));
 
-  for (var i = 8; i <= 14; i++) {
+  for (var i = 9; i <= 15; i++) {
     var osx_version = '10.' + i;
     var elt = this.prepareChartDiv(
       'osx-' + osx_version,

--- a/www/constants.js
+++ b/www/constants.js
@@ -247,6 +247,7 @@ var OSXNameMap = {
   '10.12': 'Sierra',
   '10.13': 'High Sierra',
   '10.14': 'Mojave',
+  '10.15': 'Catalina',
 };
 
 function DarwinVersionToOSX(darwin_version)


### PR DESCRIPTION
This also makes us no longer display the empty pie chart for 10.8, which Firefox no longer runs on.