### PR TITLE
Change default project to mozdata in bigquery_shim

### DIFF
--- a/analyses/bigquery_shim/bigquery_shim/dashboard.py
+++ b/analyses/bigquery_shim/bigquery_shim/dashboard.py
@@ -16,7 +16,7 @@ def fetch_results(
     end_date,
     channel=None,
     min_firefox_version="53",
-    project_id="moz-fx-data-shared-prod",
+    project_id="mozdata",
     dataset_id="analysis",
     table_id="graphics_telemetry_dashboard_tmp",
 ):

--- a/analyses/bigquery_shim/bigquery_shim/trends.py
+++ b/analyses/bigquery_shim/bigquery_shim/trends.py
@@ -18,7 +18,7 @@ def fetch_results(
     spark,
     start_date,
     end_date,
-    project_id="moz-fx-data-shared-prod",
+    project_id="mozdata",
     dataset_id="analysis",
     table_id="graphics_telemetry_trends_tmp",
 ):


### PR DESCRIPTION
This is to support changes to the analysis dataset noted here https://mail.mozilla.org/pipermail/fx-data-dev/2021-February/000397.html (`moz-fx-data-shared-prod.analysis` is now read-only)

cc @mikokm 